### PR TITLE
fix: fix cron syntax of schedule

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@
 name: Deploy beta version
 on:
   schedule:
-    - cron: 0 0 * * 6 # Every Saturday at 0000 UTC
+    - cron: '0 0 * * 6' # Every Saturday at 0000 UTC
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@
 name: Deploy beta version
 on:
   schedule:
-    - cron: '0 0 * * 6' # Every Saturday at 0000 UTC
+    - cron: '0 0 * * 1' # Every Monday at 0000 UTC
 
 jobs:
   deploy:


### PR DESCRIPTION
The deployment did not run because the syntax was incorrectly specified. It is necessary to enclose cron schedule in `''`. See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule.

I also changed the day from Saturday to Monday for testing the deployment.