### PR TITLE
set up declarative releases for Spoon

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -1,6 +1,6 @@
 [
   {
-    "commit_sha": "3443644a9453a107fc4afdbb0cca52cad102c405",
+    "commit_sha": "17e000b58363dee4ee1687e582f13ef993b387e0",
     "version": "10.1.0"
   }
 ]

--- a/releases.json
+++ b/releases.json
@@ -1,0 +1,6 @@
+[
+  {
+    "commit_sha": "3443644a9453a107fc4afdbb0cca52cad102c405",
+    "version": "10.1.0"
+  }
+]


### PR DESCRIPTION
Problem being solved: 

1. it's hard to know which commit is released, and what is the commit behind a release
2. current CD of releases is convoluted
 
Solution: have a declarative specification of releases.

Next a script to be written will take this data as input and push to Maven Central appropriately.