### PR TITLE
chore: Add option to trigger deployment manually

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,7 @@
 
 name: Deploy beta version
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * 2' # Every Tuesday at 0000 UTC
 


### PR DESCRIPTION
The beta deployment schedule was disrupted as the workflow was disabled because of the inactivity on this repository. There have been some changes in Spoon which are required by a user so I am triggering the workflow manually to perform a release.