### PR TITLE
chore: add workflow for pushing empty commits

### DIFF
--- a/.github/workflows/keep-deploy-alive.yml
+++ b/.github/workflows/keep-deploy-alive.yml
@@ -1,0 +1,21 @@
+# Pushes empty commit to keep workkflows alive
+
+name: Keep deploy workflow alive
+on:
+  schedule:
+    - cron: 0 0 1 * * # 1st of every month
+
+jobs:
+  resuscitate:
+    if: ${{ github.ref == 'refs/heads/master' }}
+    name: 'Revive deploy workflow'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: 'Create empty commit'
+        run: |
+          git config --local user.email github-actions[bot]@users.noreply.github.com
+          git config --local user.name github-actions[bot]
+          git commit --allow-empty -m "Empty commit to keep workflows alive"
+          git push origin master


### PR DESCRIPTION
Reference: https://github.com/INRIA/spoon/issues/3890#issuecomment-1296917714

Ideally, we should push empty commits every 59 days as a workflow is disabled after 60 days of inactivity on a repository. However, I was finding it hard to encode that into a cron syntax. Thus, we push an empty commit on the 1st of every month.